### PR TITLE
Fix license file text on PyPI

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Fix license file text on PyPI #45
+        * Fix license file text on PyPI (:pr:`45`)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,13 +1,15 @@
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Fix license file text on PyPI #45
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
-
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`
+    
 v0.0.2 Oct 12, 2022
 ===================
     * Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 maintainers = [
     {name = "Alteryx, Inc."}
 ]
-license = {file = "LICENSE"}
+license = {text = "BSD 3-clause"}
 requires-python = ">=3.8,<4"
 dependencies = [
     "numpy >= 1.17.5",


### PR DESCRIPTION
- Long text shows up on PyPI
<img width="293" alt="Screen Shot 2022-10-12 at 4 50 15 PM" src="https://user-images.githubusercontent.com/8726321/195445162-021fe925-7488-4c0b-ac88-48a7a0b4c878.png">
