### PR TITLE
Update Postgres connector to ensure uniformity

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,7 @@
 Future Release
 ==============
     * Enhancements
-        * Changes MySQL and Postgres connectors to add Windows support (:pr:`46`) (:pr:`47')
+        * Changes MySQL and Postgres connectors to add Windows support (:pr:`46`) (:pr:`47`)
     * Fixes
     * Changes
         * Fix license file text on PyPI (:pr:`45`)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,7 @@
 Future Release
 ==============
     * Enhancements
-        * Changes MySQL and Postgres connectors to add Windows support (:pr:`46`) (:pr:`47`)
+        * Changes MySQL and Postgres connectors to add Windows support (:pr:`46`, :pr:`47`)
     * Fixes
     * Changes
         * Fix license file text on PyPI (:pr:`45`)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,7 @@
 Future Release
 ==============
     * Enhancements
-        * Changes MySQL connector to add Windows support (:pr:`46`)
+        * Changes MySQL and Postgres connectors to add Windows support (:pr:`46`) (:pr:`47')
     * Fixes
     * Changes
         * Fix license file text on PyPI (:pr:`45`)

--- a/featuretools_sql/db_connectors/postgres_connector.py
+++ b/featuretools_sql/db_connectors/postgres_connector.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Tuple
 
 import pandas as pd
 import pandas.io.sql as sqlio
-import psycopg2
+from sqlalchemy import create_engine
 from featuretools import EntitySet
 
 
@@ -10,20 +10,9 @@ class PostgresConnector:
     def __init__(self, host, port, database, user, password, schema):
 
         if password:
-            self.postgres_connection = psycopg2.connect(
-                host=host,
-                port=port,
-                database=database,
-                user=user,
-                password=password,
-            )
+            self.engine = create_engine(f"postgresql://{user}:{password}@{host}:{port}/{database}")
         else:
-            self.postgres_connection = psycopg2.connect(
-                host=host,
-                port=port,
-                database=database,
-                user=user,
-            )
+            self.engine = create_engine(f"postgresql://{user}@{host}:{port}/{database}")
 
         self.system_name = "postgresql"
         self.user = user
@@ -120,7 +109,7 @@ class PostgresConnector:
         return string[string.find(".") + 1 :]
 
     def run_query(self, query: str) -> pd.DataFrame:
-        return sqlio.read_sql_query(query, self.postgres_connection)
+        return sqlio.read_sql_query(query, self.engine)
 
     def get_entityset(self) -> EntitySet:
         dataframes = self.populate_dataframes()

--- a/featuretools_sql/db_connectors/postgres_connector.py
+++ b/featuretools_sql/db_connectors/postgres_connector.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Tuple
 
 import pandas as pd
 import pandas.io.sql as sqlio
-from sqlalchemy import create_engine
 from featuretools import EntitySet
+from sqlalchemy import create_engine
 
 
 class PostgresConnector:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "numpy >= 1.17.5",
     "pandas >= 1.3.0",
     "featuretools >= 1.5.0",
-    "psycopg2 >= 2.9.3",
     "sqlalchemy >= 1.4.2",
     "PyMySQL >= 1.0.2",
     "snowflake-sqlalchemy[pandas] >= 1.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "numpy >= 1.17.5",
     "pandas >= 1.3.0",
     "featuretools >= 1.5.0",
+    "psycopg2 >= 2.9.3",
     "sqlalchemy >= 1.4.2",
     "PyMySQL >= 1.0.2",
     "snowflake-sqlalchemy[pandas] >= 1.4.2"


### PR DESCRIPTION
- Partially fixes #39 
- Will still need psycopg2 as a strict requirement for sqlalchemy