### PR TITLE
Handle mixed case for SnowFlake table names

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,7 @@ Future Release
     * Enhancements
         * Add latest dependency checker and checkdeps Makefile command (:pr:`59`) (:pr:`60`)
     * Fixes
-        * Fix issue with primary key handling with Snowflake (:pr:`67`)
+        * Fix issue with column case sensitivity with Snowflake (:pr:`67`) (:pr:`69`)
     * Changes
     * Documentation Changes
        * Update README.md with new library logo (:pr:`57`, :pr:`58`)

--- a/featuretools_sql/db_connectors/snowflake_connector.py
+++ b/featuretools_sql/db_connectors/snowflake_connector.py
@@ -51,7 +51,6 @@ class SnowflakeConnector:
             dataframes[table] = (table_df, table_key)
         return dataframes
 
-
     def get_table(self, table: str) -> pd.DataFrame:
         return self.run_query(f"SELECT * FROM {self.database}.{self.schema}.{table}")
 


### PR DESCRIPTION
- Snowflake automatically converts column names to uppercase, unless the name is explicitly double-quoted. 
- On import, Pandas automatically lowercases all uppercase names, except for mixed case names. 
- So when creating the EntitySet data structure, we should leave mixed-case names alone